### PR TITLE
Adding Dockerfile and Makefile for apache-spark version 1.5.0 (resolves #12)

### DIFF
--- a/apache-spark/Dockerfile
+++ b/apache-spark/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu
+
+MAINTAINER John Vivian, jtvivian@gmail.com
+
+RUN apt-get update && \
+  apt-get install -y python libnss3 openjdk-7-jre-headless curl
+
+RUN mkdir /opt/apache-spark && \
+  curl http://apache.osuosl.org/spark/spark-1.5.0/spark-1.5.0-bin-hadoop2.6.tgz \
+  | tar --strip-components=1 -xzC /opt/apache-spark
+
+ENV PATH /opt/apache-spark/bin:$PATH
+
+RUN mkdir /data
+WORKDIR /data
+
+ENTRYPOINT ["spark-submit"]

--- a/apache-spark/Makefile
+++ b/apache-spark/Makefile
@@ -1,0 +1,10 @@
+build_tool = runtime-container.DONE
+build_number ?= none
+git_commit ?= $(shell git rev-parse HEAD)
+nametag = computationalgenomicslab/apache-spark:1.5.0--tgz--unstable--${git_commit}--${build_number}
+
+all: ${build_tool}
+
+${build_tool}: Dockerfile
+	docker build -t ${nametag} .
+	touch ${build_tool}


### PR DESCRIPTION
Progress towards #12.

A few questions in advance:
- is it ok to keep John as maintainer?
- has anyone figured out the proper way to hit the Apache download closer script with curl?
- is `tgz` appropriate for srcType in the tag name?
- will apache-spark require a wrapper script?
