### PR TITLE
HDFS datanodes should store data on a mounted volume.

### DIFF
--- a/apache-hadoop-common/runtime/Dockerfile
+++ b/apache-hadoop-common/runtime/Dockerfile
@@ -48,7 +48,7 @@ RUN chmod +x $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
 # add conf files
 ADD hadoop-docker/core-site.xml.template $HADOOP_PREFIX/etc/hadoop/core-site.xml.template
 RUN sed -i s/9000/8020/ $HADOOP_PREFIX/etc/hadoop/core-site.xml.template 
-ADD hadoop-docker/hdfs-site.xml $HADOOP_PREFIX/etc/hadoop/hdfs-site.xml
+ADD hdfs-site.xml $HADOOP_PREFIX/etc/hadoop/hdfs-site.xml
 ADD hadoop-docker/mapred-site.xml $HADOOP_PREFIX/etc/hadoop/mapred-site.xml
 ADD hadoop-docker/yarn-site.xml $HADOOP_PREFIX/etc/hadoop/yarn-site.xml.template
 ADD hadoop-docker/ssh_config /root/.ssh/config

--- a/apache-hadoop-common/runtime/hdfs-site.xml
+++ b/apache-hadoop-common/runtime/hdfs-site.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+    <property>
+        <name>dfs.datanode.data.dir</name>
+        <value>/ephemeral/hdfs/</value>
+    </property>
+</configuration>

--- a/apache-hadoop-worker/start-worker.sh
+++ b/apache-hadoop-worker/start-worker.sh
@@ -4,6 +4,9 @@ HADOOP_PREFIX=/opt/apache-hadoop
 HADOOP_CONF_DIR=${HADOOP_PREFIX}/etc/hadoop
 ln -s ${HADOOP_PREFIX} /usr/local/hadoop
 
+# make a directory in the mounted volume
+mkdir /ephemeral/hdfs
+
 # overwrite hostname in conf
 if [ $# -ne 0 ]; then
     sed "s/HOSTNAME/${1}/g" $HADOOP_PREFIX/etc/hadoop/core-site.xml.template > $HADOOP_PREFIX/etc/hadoop/core-site.xml


### PR DESCRIPTION
Without setting this configuration option (and making an accompanying change to the cluster launch scripts), the datanodes will write their data to the Docker root volume which has something silly like 20GB of space.
