### PR TITLE
Update ADAM container commit version

### DIFF
--- a/adam/Makefile
+++ b/adam/Makefile
@@ -6,7 +6,7 @@ runtime_fullpath = $(realpath ${runtime_path})
 build_tool = runtime-container.DONE
 build_number ?= none
 git_commit ?= $(shell git rev-parse HEAD)
-nametag = quay.io/ucsc_cgl/adam:49b614d
+nametag = quay.io/ucsc_cgl/adam:cd6ef41
 
 # Steps
 build: ${build_output} ${build_tool}

--- a/adam/build/Dockerfile
+++ b/adam/build/Dockerfile
@@ -9,5 +9,5 @@ RUN git clone https://github.com/bigdatagenomics/adam.git
 
 # build adam
 WORKDIR /home/adam
-RUN git checkout 49b614d5334871e4ea879290bec650e0ab94edaf
+RUN git checkout cd6ef4162ae97460059ef067d21bbed7e060b289
 RUN /opt/apache-maven-3.3.3/bin/mvn package -DskipTests


### PR DESCRIPTION
Lock ADAM docker container to https://github.com/bigdatagenomics/adam/commit/cd6ef4162ae97460059ef067d21bbed7e060b289 which is https://github.com/bigdatagenomics/adam/pull/921.
