### PR TITLE
Adding docker image for S3AM

### DIFF
--- a/s3am/Dockerfile
+++ b/s3am/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:12.04
+
+MAINTAINER Frank Austin Nothaft
+
+# install necessary dependencies
+RUN apt-get update && \
+    apt-get install -y python-dev \
+            gcc \
+            make \
+            libcurl4-openssl-dev \
+            python-virtualenv
+
+# create virtualenv and install s3am
+RUN virtualenv /opt/s3am && . /opt/s3am/bin/activate
+RUN pip install s3am
+
+# add wrapper script
+WORKDIR /opt/
+ADD wrapper.sh /opt/wrapper.sh
+
+ENTRYPOINT ["bash", "+x", "/opt/wrapper.sh"]

--- a/s3am/Makefile
+++ b/s3am/Makefile
@@ -1,0 +1,25 @@
+# Definitions
+build_tool = runtime-container.DONE
+name = quay.io/ucsc_cgl/s3am
+tag = 1.0a1
+
+# Steps
+build: ${build_output} ${build_tool}
+
+${build_tool}: Dockerfile
+	docker build -t ${name}:${tag} .
+	docker tag -f ${name}:${tag} ${name}:latest
+	touch ${build_tool}
+
+push: build
+	# Requires ~/.dockercfg
+	docker push ${name}:${tag}
+	docker push ${name}:latest
+
+test: build
+	python test.py
+
+clean:
+	-rm ${build_tool}
+	-rm ${build_output}
+	docker rmi ${name}:${tag}

--- a/s3am/test.py
+++ b/s3am/test.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python2.7
+# @author Frank Austin Nothaft fnothaft@berkeley.edu
+import subprocess
+import tempfile
+import unittest
+
+
+class TestS3AM(unittest.TestCase):
+
+    def test_docker_call(self):
+        out, err = check_docker_output(tool='quay.io/ucsc_cgl/s3am:1.0a1')
+        self.assertTrue('usage: s3am [--help] {upload,cancel,verify} ...')
+
+def check_docker_output(tool):
+    command = 'docker run ' + tool
+    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output = process.communicate()
+    return output
+
+if __name__ == '__main__':
+    unittest.main()

--- a/s3am/wrapper.sh
+++ b/s3am/wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# activate s3am virtualenv
+source /opt/s3am/bin/activate
+
+# run command
+s3am $@


### PR DESCRIPTION
We have a lab machine where the default build steps for s3am don't work due to dependency conflicts. Unless anyone objects, I would like to call s3am from Docker instead of relying on an s3am install to exist on the system.
