### PR TITLE
Move away from UID in bash for bwakit.

### DIFF
--- a/bwakit/wrapper.sh
+++ b/bwakit/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 


### PR DESCRIPTION
Updating the $UID variable in Bash causes a failure, as UID is a bash internal variable.

@hannes-ucsc @jpdna between this, #83, and #84, https://github.com/BD2KGenomics/toil-scripts/issues/106 appears to be resolved. At least, it is on my side. @jpdna I'll send you a pointer to my latest branch for you to test.
