### PR TITLE
Wrapper consistency (resolves #86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,17 @@ All tools should be on their own branch while under development.  Once a tool is
 Every image should have a wrapper script set as the `ENTRYPOINT` which handles launching the tool (with parameters), and importantly, changing the ownership of all output files to the owner of the mounted **/data** directory.  This wrapper script allows for all kinds of flexibility, as the example below shows the wrapper script handling ownership of output files from root to the host user as well as using environment variables to allow any number of java options to be passed during jar execution. An example of a wrapper script for gatk is shown below:
 ```
 #!/usr/bin/env bash
+
+# Fix ownership of output files
+finish() {
+    # Fix ownership of output files
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
+}
+trap finish EXIT
+
 # Call tool with parameters
 java $JAVA_OPTS -jar /opt/cgl-docker-lib/gatk.jar "$@"
-# Fix ownership of output files
-UID=$(stat -c '%u:%g' /data)
-chown -R $UID /data
 ```
 
 ## Standards Within the Genomics Community

--- a/bwa/runtime/wrapper.sh
+++ b/bwa/runtime/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/bwa/runtime/wrapper.sh
+++ b/bwa/runtime/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/bwakit/wrapper.sh
+++ b/bwakit/wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Fix ownership of output files
 finish() {

--- a/bwakit/wrapper.sh
+++ b/bwakit/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/conductor/runtime/wrapper.sh
+++ b/conductor/runtime/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 SPARK_SUBMIT=/opt/cgl-docker-lib/apache-spark/bin/spark-submit
 CONDUCTOR_JAR=/opt/cgl-docker-lib/conductor/conductor/target/conductor-0.5-SNAPSHOT-distribution.jar

--- a/conductor/runtime/wrapper.sh
+++ b/conductor/runtime/wrapper.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 SPARK_SUBMIT=/opt/cgl-docker-lib/apache-spark/bin/spark-submit
 CONDUCTOR_JAR=/opt/cgl-docker-lib/conductor/conductor/target/conductor-0.5-SNAPSHOT-distribution.jar

--- a/cutadapt/wrapper.sh
+++ b/cutadapt/wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Fix ownership of output files

--- a/cutadapt/wrapper.sh
+++ b/cutadapt/wrapper.sh
@@ -4,8 +4,8 @@ set -e
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/fastq-dump/wrapper.sh
+++ b/fastq-dump/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/fastq-dump/wrapper.sh
+++ b/fastq-dump/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/gatk/runtime/wrapper.sh
+++ b/gatk/runtime/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/gatk/runtime/wrapper.sh
+++ b/gatk/runtime/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/genetorrent/wrapper.sh
+++ b/genetorrent/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/genetorrent/wrapper.sh
+++ b/genetorrent/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/kallisto/wrapper.sh
+++ b/kallisto/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/kallisto/wrapper.sh
+++ b/kallisto/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/mapsplice-2.0.1.9/runtime/wrapper.sh
+++ b/mapsplice-2.0.1.9/runtime/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/mapsplice-2.0.1.9/runtime/wrapper.sh
+++ b/mapsplice-2.0.1.9/runtime/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/mapsplice/runtime/wrapper.sh
+++ b/mapsplice/runtime/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/mapsplice/runtime/wrapper.sh
+++ b/mapsplice/runtime/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/mutect/runtime/wrapper.sh
+++ b/mutect/runtime/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/mutect/runtime/wrapper.sh
+++ b/mutect/runtime/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/picardtools/wrapper.sh
+++ b/picardtools/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/picardtools/wrapper.sh
+++ b/picardtools/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/pindel/wrapper.sh
+++ b/pindel/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/pindel/wrapper.sh
+++ b/pindel/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/rnaseqc/wrapper.sh
+++ b/rnaseqc/wrapper.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
+
+# Fix ownership of output files
+finish() {
+    # Fix ownership of output files
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
+}
+trap finish EXIT
+
 # Call tool with parameters
 java $JAVA_OPTS -jar /opt/rnaseqc/RNA-SeQC_v1.1.8.jar "$@"
-# Fix ownership of output files
-UID=$(stat -c '%u:%g' /data)
-chown -R $UID /data
 

--- a/rnaseqc/wrapper.sh
+++ b/rnaseqc/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/rsem-1.1.13/wrapper.sh
+++ b/rsem-1.1.13/wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Fix ownership of output files

--- a/rsem-1.1.13/wrapper.sh
+++ b/rsem-1.1.13/wrapper.sh
@@ -4,8 +4,8 @@ set -e
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/rsem/wrapper.sh
+++ b/rsem/wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Fix ownership of output files

--- a/rsem/wrapper.sh
+++ b/rsem/wrapper.sh
@@ -4,8 +4,8 @@ set -e
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/samtools-1.3/wrapper.sh
+++ b/samtools-1.3/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/samtools-1.3/wrapper.sh
+++ b/samtools-1.3/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/samtools/wrapper.sh
+++ b/samtools/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/samtools/wrapper.sh
+++ b/samtools/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/snpeff/wrapper.sh
+++ b/snpeff/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/snpeff/wrapper.sh
+++ b/snpeff/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/star/wrapper.sh
+++ b/star/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/star/wrapper.sh
+++ b/star/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/ubu-1.0/wrapper.sh
+++ b/ubu-1.0/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/ubu-1.0/wrapper.sh
+++ b/ubu-1.0/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {

--- a/ubu/wrapper.sh
+++ b/ubu/wrapper.sh
@@ -3,8 +3,8 @@
 # Fix ownership of output files
 finish() {
     # Fix ownership of output files
-    UID=$(stat -c '%u:%g' /data)
-    chown -R $UID /data
+    user_id=$(stat -c '%u:%g' /data)
+    chown -R ${user_id} /data
 }
 trap finish EXIT
 

--- a/ubu/wrapper.sh
+++ b/ubu/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Fix ownership of output files
 finish() {


### PR DESCRIPTION
Resolves #86 by 
- adding the permission fix to all wrappers, except conductor
- have the permission fix use the trap shell built-in
- use `env` to locate bash in the wrapper shebangs
- use `set -e` in all wrappers
