### PR TITLE
Containerize RNA-seq pipeline (resolves #106, resolves #108, resolves #109, resolves #113)

### DIFF
--- a/rnaseq-cgl-pipeline/Dockerfile
+++ b/rnaseq-cgl-pipeline/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:14.04
+
+# File Author / Maintainer
+MAINTAINER John Vivian <jtvivian@gmail.com>
+
+RUN apt-get update && apt-get install -y \
+    git \
+    python-dev \
+    python-pip \
+    wget \
+    curl \
+    apt-transport-https \
+    ca-certificates
+
+# Get the 1.9.1 binary
+RUN wget https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 -O /usr/local/bin/docker
+RUN chmod u+x /usr/local/bin/docker
+
+# Install Toil
+RUN pip install toil
+
+# Install refactored rnaseq pipeline
+RUN git clone -b issues/221-refactor-rnaseq-pipeline https://github.com/BD2KGenomics/toil-scripts \
+    /opt/rnaseq-pipeline
+
+COPY wrapper.py /opt/rnaseq-pipeline/
+COPY README.md /opt/rnaseq-pipeline/
+
+ENTRYPOINT ["python", "/opt/rnaseq-pipeline/wrapper.py"]
+CMD ["--help"]

--- a/rnaseq-cgl-pipeline/Dockerfile
+++ b/rnaseq-cgl-pipeline/Dockerfile
@@ -20,8 +20,8 @@ RUN chmod u+x /usr/local/bin/docker
 RUN pip install toil
 
 # Install refactored rnaseq pipeline
-RUN git clone -b issues/221-refactor-rnaseq-pipeline https://github.com/BD2KGenomics/toil-scripts \
-    /opt/rnaseq-pipeline
+RUN git clone https://github.com/BD2KGenomics/toil-scripts /opt/rnaseq-pipeline
+RUN cd /opt/rnaseq-pipeline && git reset --hard 77510fb075f5865050621968e2dc6b2ac8cf7c87
 
 COPY wrapper.py /opt/rnaseq-pipeline/
 COPY README.md /opt/rnaseq-pipeline/

--- a/rnaseq-cgl-pipeline/Makefile
+++ b/rnaseq-cgl-pipeline/Makefile
@@ -1,0 +1,22 @@
+# Definitions
+runtime_fullpath = $(realpath runtime)
+build_tool = runtime-container.DONE
+git_commit ?= $(shell git log --pretty=oneline -n 1 -- ../rnaseq-cgl-pipeline | cut -f1 -d " ")
+name = quay.io/ucsc_cgl/rnaseq-cgl-pipeline
+tag = 732349f6dd0df3fb90fa9d7e6ee1e04a32e2e773--${git_commit}
+
+build:
+	docker build -t ${name}:${tag} .
+	docker tag -f ${name}:${tag} ${name}:latest
+	touch ${build_tool}
+
+push: build
+	# Requires ~/.dockercfg
+	docker push ${name}:${tag}
+	docker push ${name}:latest
+
+test: build
+	python test.py
+
+clean:
+	-rm ${build_tool}

--- a/rnaseq-cgl-pipeline/README.md
+++ b/rnaseq-cgl-pipeline/README.md
@@ -1,0 +1,119 @@
+# Computational Genomics Lab, Genomics Institute, UC Santa Cruz
+### Running the CGL RNA-seq Pipeline (HG38) Container
+
+This guide will walk through running the pipeline from start to finish. If there are any questions please contact
+John Vivian (jtvivian@gmail.com). If you find any errors or corrections please feel free to make a pull request.
+Feedback of any kind is appreciated.
+
+## Overview
+
+This container runs the 
+[CGL RNA-seq pipeline](https://github.com/BD2KGenomics/toil-scripts/tree/master/src/toil_scripts/rnaseq_cgl), which
+is built using [Toil](https://github.com/BD2KGenomics/toil), a high-performance pipeline architecture platform for
+running workflows. This container is designed to run local samples.
+This pipeline expects samples to be tarballs with fastq files inside, ideally paired data tagged with
+the conventional R1 and R2 standard. Samples should NOT have periods (.) in them aside from the extension.
+
+This pipeline requires a run environment with at least 40G of memory to run STAR alignment. 
+
+This pipeline requires a host with Docker 1.9.1 installed. Other versions of Docker will soon be supported.
+
+## Inputs
+
+The CGL RNA-seq pipeline requires input files in order to run. These files are hosted on Synapse and can 
+be downloaded after creating an account which takes about 1 minute. 
+
+* Register for a [Synapse account](https://www.synapse.org/#!RegisterAccount:0)
+* Either download the samples from the [website GUI](https://www.synapse.org/#!Synapse:syn5886029) or use the Python API
+* `pip install synapseclient`
+* `python`
+    * `import synapseclient`
+    * `syn = synapseclient.Synapse()`
+    * `syn.login('foo@bar.com', 'password')`
+    * Get the RSEM reference (1 G)
+        * `syn.get('syn5889216')`
+    * Get the Kallisto index (2 G)
+        * `syn.get('syn5886142')`
+    * Get the STAR index (25 G)
+        * `syn.get('syn5886182')`
+
+## Genomic tool containers
+
+Sometimes an error is thrown when attempting to pull down a Docker container that is used inside the pipeline. 
+To avoid running into these errors, run the following commmands before executing the pipeline for the first time.
+
+
+1. `docker pull quay.io/ucsc_cgl/cutadapt:1.9--6bd44edd2b8f8f17e25c5a268fedaab65fa851d2`
+2. `docker pull quay.io/ucsc_cgl/kallisto:0.42.4--35ac87df5b21a8e8e8d159f26864ac1e1db8cf86`
+3. `docker pull quay.io/ucsc_cgl/star:2.4.2a--bcbd5122b69ff6ac4ef61958e47bde94001cfe80`
+4. `docker pull quay.io/ucsc_cgl/rsem:1.2.25--d4275175cc8df36967db460b06337a14f40d2f21`
+5. `docker pull jvivian/rsem_postprocess`
+6. `docker pull jvivian/gencode_hugo_mapping`
+
+Note: This error was only seen once, so it is likely this step may not be necessary. 
+
+## Running
+
+If samples and inputs are colocated in a place with _plenty_ of storage, simply mirror the absolute path to the
+parent directory when using Docker's -v mount command. Toil's job store and temporary directories will be 
+created inside this mount point. "-v /var/run/docker.sock:/var/run/docker.sock" must always be supplied. 
+
+To reiterate, the mount for the working directory must match on both sides of the colon - 
+an error will be thrown if that is not the case. 
+
+```
+docker run \
+    -v /foo/bar:/foo/bar \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    quay.io/ucsc_cgl/rnaseq-cgl-pipeline \
+    --star /foo/bar/starIndex_hg38_no_alt.tar.gz \
+    --rsem /foo/bar/rsem_ref_hg38_no_alt.tar.gz \
+    --kallisto /foo/bar/kallisto_hg38.idx \
+    --samples /foo/bar/sample1.tar /foo/bar/sample2.tar ...
+```
+
+### Separate sample, input, and work directory locations
+
+If your samples (and/or inputs) are located in a different location than where you would like
+the job store and work directories to be created, use the following format:
+
+* Mirror mount points for the work directory: e.g. `-v /foo/bar:/foo/bar`
+* Use `-v /foo/bar/samples:/samples`, where `:/samples` is the preferred destination path.
+* Use `-v /foo/bar/inputs:/inputs`, where `:/inputs` is the preferred destination path.
+
+Due to the way Docker works, this will change how you supply paths to the samples and inputs. Look at the 
+following example and you'll see that the path being passed to the container for samples is no longer 
+**/foo/bar/samples/sample1.tar**, but **/samples/sample1.tar**.  Likewise, the inputs are now passed in
+as **/inputs/kallisto_hg38.idx**. 
+
+```
+docker run \
+    -v /scratch:/scratch \ # Path to work directory, mirrored
+    -v /path/to/data:/samples \ # Path to samples, not mirrored
+    -v /path/to/inputs:/inputs \ # Path to inputs, not mirrored
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    quay.io/ucsc_cgl/rnaseq-cgl-pipeline \
+    --star /inputs/starIndex_hg38_no_alt.tar.gz \
+    --rsem /inputs/rsem_ref_hg38_no_alt.tar.gz \
+    --kallisto /inputs/kallisto_hg38.idx
+    --samples /samples/sample1.tar /samples/sample2.tar ...
+```
+
+## Restarting
+
+In the event of failure, the pipeline can be restarted by re-running the Docker command with the `--restart` argument.
+
+## Into the Weeds
+
+/var/run/docker.sock needs to be mirror mounted so that the host daemon process can spawn sibling containers when
+Docker is executed by the parent container as opposed to nesting Docker containers as children which is ill-advised.
+
+The mirror mount for the work directory is required since the Docker call executed inside the parent container
+is actually run by the host, meaning the "src" provided to "-v" is actually on the host, not the parent container.
+
+When using multiple mount points, A non-mirrored destination is required because there isn't an easy way to
+ascertain which of the mount points is the work path versus sample path. That's because the JSON
+returned by Docker inspect isn't ordered.  
+
+You can use whatever mount point you like for the samples and inputs _so long as they are not mirrored_ and
+you are consistent about using the dst path when passing in arguments to the container.

--- a/rnaseq-cgl-pipeline/dockstore.cwl
+++ b/rnaseq-cgl-pipeline/dockstore.cwl
@@ -1,0 +1,54 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+description: "A Docker container of the RNA-seq CGL Pipeline."
+id: "rnaseq-cgl-pipeline"
+label: "RNA-seq CGL Pipeline"
+
+dct:creator:
+  "@id": "http://orcid.org/0000-0002-4778-7723"
+  foaf:name: John Vivian
+  foaf:mbox: "mailto:jtvivian@gmail.com"
+
+requirements:
+  - class: DockerRequirement
+	dockerPull: "quay.io/ucsc_cgl/rnaseq-cgl-pipeline"
+  - { import: node-engine.cwl }
+
+hints:
+  - class: ResourceRequirement
+	coresMin: 1
+	ramMin: 40920
+	outdirMin: 512000
+	description: "the process requires at leasrt 40G of RAM"
+
+inputs:
+  - id: "#star"
+	type: string
+	description: "Absolute path to the star index tarball"
+	inputBinding:
+	  position: 1
+	  prefix: "--star"
+
+  - id: "#rsem"
+	type: string
+	description: "Absolute path to the rsem reference tarball"
+	inputBinding:
+	  position: 2
+	  prefix: "--rsem"
+
+  - id: "#star"
+	type: string
+	description: "Absolute path to the kallisto index file"
+	inputBinding:
+	  position: 3
+	  prefix: "--kallisto"
+
+outputs:
+  - id: "#rnaseq-output"
+	type: File
+	outputBinding:
+	  glob: .tar.gz
+	description: "A tarball that contains quantification data."
+
+baseCommand: ["--star", "", "--rsem", "", "--kallisto", ""]

--- a/rnaseq-cgl-pipeline/test.py
+++ b/rnaseq-cgl-pipeline/test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python2.7
+# John Vivian
+import subprocess
+import unittest
+
+
+class TestRNASeqPipeline(unittest.TestCase):
+
+    def test_docker_call(self):
+        tool = ['quay.io/ucsc_cgl/rnaseq-cgl-pipeline']
+        base = ['docker', 'run']
+        args = ['--star=/foo', '--rsem=/foo', '--kallisto=/foo', '--samples=/foo']
+        sock = ['-v', '/var/run/docker.sock:/var/run/docker.sock']
+        mirror = ['-v', '/foo:/foo']
+        sample = ['-v', '/bar:/samples']
+        inputs = ['-v', '/foobar:/inputs']
+        # Check base call for help menu
+        out = check_docker_output(command=base + tool)
+        self.assertTrue('Please see the complete documentation' in out)
+        self.assertFalse('foo bar' in out)
+        # Check for not enough mirror mounts
+        self.assertTrue('IllegalArgumentException' in check_docker_output(base + sock + tool + args))
+        # Check for too many binds to docker socket
+        self.assertTrue('Duplicate bind mount' in check_docker_output(
+            base + sock + ['-v', '/foo:/var/run/docker.sock'] + mirror + tool + args))
+        # Check for mirror mount when input/sample mount is used
+        self.assertTrue('IllegalArgumentException' in check_docker_output(base + sock + sample + inputs + tool + args))
+        # Check for more than one mirror mount
+        self.assertTrue('IllegalArgumentException' in check_docker_output(
+            base + sock + mirror +  ['-v', '/bar:/bar'] + tool + args))
+
+
+def check_docker_output(command):
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output = process.communicate()
+    return output[0]
+
+
+class IllegalArgumentException(Exception):
+    pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rnaseq-cgl-pipeline/test.py
+++ b/rnaseq-cgl-pipeline/test.py
@@ -18,15 +18,15 @@ class TestRNASeqPipeline(unittest.TestCase):
         out = check_docker_output(command=base + tool)
         self.assertTrue('Please see the complete documentation' in out)
         self.assertFalse('foo bar' in out)
-        # Check for not enough mirror mounts
-        self.assertTrue('IllegalArgumentException' in check_docker_output(base + sock + tool + args))
+        # Check for required mirror mounts
+        self.assertTrue('No required mirror mount' in check_docker_output(base + sock + tool + args))
         # Check for too many binds to docker socket
         self.assertTrue('Duplicate bind mount' in check_docker_output(
             base + sock + ['-v', '/foo:/var/run/docker.sock'] + mirror + tool + args))
         # Check for mirror mount when input/sample mount is used
-        self.assertTrue('IllegalArgumentException' in check_docker_output(base + sock + sample + inputs + tool + args))
+        self.assertTrue('No required mirror mount' in check_docker_output(base + sock + sample + inputs + tool + args))
         # Check for more than one mirror mount
-        self.assertTrue('IllegalArgumentException' in check_docker_output(
+        self.assertTrue('Too many mirror mount' in check_docker_output(
             base + sock + mirror +  ['-v', '/bar:/bar'] + tool + args))
 
 
@@ -35,9 +35,6 @@ def check_docker_output(command):
     output = process.communicate()
     return output[0]
 
-
-class IllegalArgumentException(Exception):
-    pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/rnaseq-cgl-pipeline/test.py
+++ b/rnaseq-cgl-pipeline/test.py
@@ -27,7 +27,7 @@ class TestRNASeqPipeline(unittest.TestCase):
         self.assertTrue('No required mirror mount' in check_docker_output(base + sock + sample + inputs + tool + args))
         # Check for more than one mirror mount
         self.assertTrue('Too many mirror mount' in check_docker_output(
-            base + sock + mirror +  ['-v', '/bar:/bar'] + tool + args))
+            base + sock + mirror + ['-v', '/bar:/bar'] + tool + args))
 
 
 def check_docker_output(command):

--- a/rnaseq-cgl-pipeline/test.py
+++ b/rnaseq-cgl-pipeline/test.py
@@ -15,7 +15,7 @@ class TestRNASeqPipeline(unittest.TestCase):
         sample = ['-v', '/bar:/samples']
         inputs = ['-v', '/foobar:/inputs']
         # Check base call for help menu
-        out = check_docker_output(command=base + tool)
+        out = check_docker_output(command=base + tool, assert_1=False)
         self.assertTrue('Please see the complete documentation' in out)
         self.assertFalse('foo bar' in out)
         # Check for required mirror mounts
@@ -30,9 +30,13 @@ class TestRNASeqPipeline(unittest.TestCase):
             base + sock + mirror + ['-v', '/bar:/bar'] + tool + args))
 
 
-def check_docker_output(command):
+def check_docker_output(command, assert_1=True):
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     output = process.communicate()
+    if assert_1:
+        assert process.returncode == 1
+    else:
+        assert process.returncode == 0
     return output[0]
 
 

--- a/rnaseq-cgl-pipeline/wrapper.py
+++ b/rnaseq-cgl-pipeline/wrapper.py
@@ -1,0 +1,101 @@
+import argparse
+import os
+import shutil
+import subprocess
+import json
+import logging
+from uuid import uuid4
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger()
+
+
+def call_pipeline(mount, args):
+    uuid = 'Toil-RNAseq-' + str(uuid4())
+    if not os.path.exists(mount + uuid):
+        os.makedirs(os.path.join(mount, uuid))
+    os.environ['PYTHONPATH'] = '/opt/rnaseq-pipeline/src'
+    command = ['python', '-m', 'toil_scripts.rnaseq_cgl.rnaseq_cgl_pipeline',
+               os.path.join(mount, 'jobStore'),
+               '--retryCount', '1',
+               '--output-dir', mount,
+               '--workDir', os.path.join(mount, uuid),
+               '--star-index', 'file://'+ args.star,
+               '--rsem-ref', 'file://' + args.rsem,
+               '--kallisto-index', 'file://' + args.kallisto,
+               '--sample-urls']
+    command.extend(['file://' + x for x in args.samples])
+    if args.restart:
+        command.append('--restart')
+    try:
+        subprocess.check_call(command)
+    finally:
+        stat = os.stat(mount)
+        subprocess.check_call(['chown', '-R', '{}:{}'.format(stat.st_uid, stat.st_gid), mount])
+        shutil.rmtree(os.path.join(mount, uuid))
+
+
+def main():
+    """
+    Please see the complete documentation located at:
+    https://github.com/BD2KGenomics/cgl-docker-lib/tree/master/rnaseq-cgl-pipeline
+    or in the container at:
+    /opt/rnaseq-pipeline/README.md
+
+    All samples and inputs must be reachable via Docker "-v" mount points and use
+    the Destination path prefix.
+    """
+    # Define argument parser for
+    parser = argparse.ArgumentParser(description=main.__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('--star', type=str, required=True,
+                        help='Absolute path to Star Index tarball.')
+    parser.add_argument('--rsem', type=str, required=True,
+                        help='Absolute path to rsem reference tarball.')
+    parser.add_argument('--kallisto', type=str, required=True,
+                        help='Absolute path to kallisto index (.idx) file.')
+    parser.add_argument('--samples', nargs='+', required=True,
+                        help='Absolute path(s) to sample tarballs.')
+    parser.add_argument('--restart', action='store_true', default=False,
+                        help='Add this flag to restart the pipeline. Requires existing job store.')
+    args = parser.parse_args()
+    # Get name of most recent running container (should be this one)
+    name = subprocess.check_output(['docker', 'ps', '--format', '{{.Names}}']).split('\n')[0]
+    # Get name of mounted volume
+    blob = json.loads(subprocess.check_output(['docker', 'inspect', name]))
+    mounts = blob[0]['Mounts']
+    # Ensure docker.sock is mounted correctly
+    sock_mount = [x['Source'] == x['Destination'] for x in mounts if 'docker.sock' in x['Source']]
+    if len(sock_mount) != 1:
+        raise IllegalArgumentException('Missing socket mount. Requires the following:'
+                                       'docker run -v /var/run/docker.sock:/var/run/docker.sock')
+    # Ensure formatting of command for 2 mount points
+    if len(mounts) == 2:
+        if not all(x['Source'] == x['Destination'] for x in mounts):
+            raise IllegalArgumentException('Docker Src/Dst mount points, invoked with the -v argument,'
+                                           'must be the same if only using one mount point aside from the '
+                                           'docker socket.')
+        work_mount = [x['Source'] for x in mounts if 'docker.sock' not in x['Source']]
+    else:
+        # Ensure only one mirror mount exists aside from docker.sock
+        mirror_mounts = [x['Source'] for x in mounts if x['Source'] == x['Destination']]
+        work_mount = [x for x in mirror_mounts if 'docker.sock' not in x]
+        if len(work_mount) > 1:
+            raise IllegalArgumentException('Too many mirror mount points provided, see documentation.')
+        if len(work_mount) == 0:
+            raise IllegalArgumentException('No required mirror mount point provided, see documentation.')
+    # Enforce file input standards
+    if not all(x.startswith('/') for x in args.samples):
+        raise IllegalArgumentException("Sample inputs must point to a file's full path, e.g. "
+                                       "'/full/path/to/sample1.tar'. You provided {}.".format(args.samples))
+    if not all(x.startswith('/') for x in [args.star, args.kallisto, args.rsem]):
+        raise IllegalArgumentException("Sample inputs must point to a file's full path, e.g. "
+                                       "'/full/path/to/sample1.tar'. You  provided {}.".format(args.samples))
+    call_pipeline(work_mount[0], args)
+
+
+class IllegalArgumentException(Exception):
+    pass
+
+
+if __name__ == '__main__':
+    main()

--- a/rnaseq-cgl-pipeline/wrapper.py
+++ b/rnaseq-cgl-pipeline/wrapper.py
@@ -20,11 +20,11 @@ def call_pipeline(mount, args):
                '--retryCount', '1',
                '--output-dir', mount,
                '--workDir', os.path.join(mount, uuid),
-               '--star-index', 'file://'+ args.star,
+               '--star-index', 'file://' + args.star,
                '--rsem-ref', 'file://' + args.rsem,
                '--kallisto-index', 'file://' + args.kallisto,
                '--sample-urls']
-    command.extend(['file://' + x for x in args.samples])
+    command.extend('file://' + x for x in args.samples)
     if args.restart:
         command.append('--restart')
     try:

--- a/rnaseq-cgl-pipeline/wrapper.py
+++ b/rnaseq-cgl-pipeline/wrapper.py
@@ -12,7 +12,7 @@ log = logging.getLogger()
 
 def call_pipeline(mount, args):
     uuid = 'Toil-RNAseq-' + str(uuid4())
-    if not os.path.exists(mount + uuid):
+    if not os.path.isdir(mount + uuid):
         os.makedirs(os.path.join(mount, uuid))
     os.environ['PYTHONPATH'] = '/opt/rnaseq-pipeline/src'
     command = ['python', '-m', 'toil_scripts.rnaseq_cgl.rnaseq_cgl_pipeline',

--- a/rnaseq-cgl-pipeline/wrapper.py
+++ b/rnaseq-cgl-pipeline/wrapper.py
@@ -48,7 +48,7 @@ def main():
     # Define argument parser for
     parser = argparse.ArgumentParser(description=main.__doc__, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('--star', type=str, required=True,
-                        help='Absolute path to Star Index tarball.')
+                        help='Absolute path to STAR index tarball.')
     parser.add_argument('--rsem', type=str, required=True,
                         help='Absolute path to rsem reference tarball.')
     parser.add_argument('--kallisto', type=str, required=True,


### PR DESCRIPTION
samples/inputs/jobstore/workdir all on one mount point:

```
docker run -v /var/run/docker.sock:/var/run/docker.sock \
-v /data/container-test-rnaseq:/data/container-test-rnaseq \
jvivian/rnaseq-cgl-pipeline \
--star /data/container-test-rnaseq/inputs/starIndex_chr6.tar.gz \
--rsem /data/container-test-rnaseq/inputs/rsem_ref_chr6.tar.gz \
--kallisto /data/container-test-rnaseq/inputs/kallisto_hg38.idx \
--samples /data/container-test-rnaseq/samples/test_input.tar.gz /data/container-test-rnaseq/samples/test_input_dup.tar.gz
```

samples, inputs, jobstore/workdir on separate mount points:

```
docker run -v /var/run/docker.sock:/var/run/docker.sock \
-v /data/container-test-rnaseq:/data/container-test-rnaseq \
-v /data/container-test-rnaseq/inputs:/inputs \
-v /data/container-test-rnaseq/samples:/samples \
jvivian/rnaseq-cgl-pipeline \
--star /inputs/starIndex_chr6.tar.gz \
--rsem /inputs/rsem_ref_chr6.tar.gz \
--kallisto /inputs/kallisto_hg38.idx \
--samples /samples/test_input.tar.gz /samples/test_input_dup.tar.gz
```
