### PR TITLE
Changed vg version to latest commit as of 7/14/2016

### DIFF
--- a/vg/Makefile
+++ b/vg/Makefile
@@ -4,7 +4,7 @@ runtime_fullpath = $(realpath runtime)
 build_tool = runtime-container.DONE
 git_commit ?= $(shell git log --pretty=oneline -n 1 -- ../vg | cut -f1 -d " ")
 name = quay.io/ucsc_cgl/vg
-tag = 1.4.0--${git_commit}
+tag = 1.4.0-960-g64573a5--${git_commit}
 
 # Steps
 build: ${build_output} ${build_tool}

--- a/vg/build/Dockerfile
+++ b/vg/build/Dockerfile
@@ -20,5 +20,6 @@ WORKDIR /home
 RUN git clone --recursive https://github.com/vgteam/vg.git
 
 WORKDIR /home/vg
+RUN git checkout 64573a50c7afbdc47bcd391d49d6c78a159838d5
 
 RUN ./source_me.sh && make static


### PR DESCRIPTION
The VG docker container needs to be updated to the latest commit as of 7/8/2016 which should be commit `cb68327d76dd718dd155a6462866e65b093d4644` of VG version 1.4.0. This is needed because changes to the vg map subcommand functionality is needed for a properly functioning vg evaluation pipeline.
