### PR TITLE
Bump to ADAM 0.20.0 release candidate (resolves #144)

### DIFF
--- a/adam/Makefile
+++ b/adam/Makefile
@@ -7,7 +7,7 @@ build_tool = runtime-container.DONE
 build_number ?= none
 git_commit ?= $(shell git rev-parse HEAD)
 name = quay.io/ucsc_cgl/adam
-tag = 962-ehf--${git_commit}
+tag = c251f79c6bde3dce12e685c6cf03d5b1c30e9273--${git_commit}
 
 # Steps
 build: ${build_output} ${build_tool}

--- a/adam/build/Dockerfile
+++ b/adam/build/Dockerfile
@@ -5,10 +5,10 @@ MAINTAINER Frank Austin Nothaft, fnothaft@berkeley.edu
 WORKDIR /home
 
 # clone adam
-RUN git clone https://github.com/fnothaft/adam.git
+RUN git clone https://github.com/bigdatagenomics/adam.git
 
 # build adam
 WORKDIR /home/adam
-RUN git checkout 962-ehf
+RUN git checkout c251f79c6bde3dce12e685c6cf03d5b1c30e9273
 
 RUN /opt/apache-maven-3.3.3/bin/mvn package -DskipTests

--- a/apache-hadoop-common/runtime/Dockerfile
+++ b/apache-hadoop-common/runtime/Dockerfile
@@ -12,12 +12,12 @@ RUN apt-get update && \
   apt-get install -y \
     python \
     libnss3 \
-    openjdk-7-jre-headless \
+    openjdk-8-jre-headless \
     openssh-server \
     openssh-client
 
 # set java path
-ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre/
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/jre/
 ENV PATH $PATH:$JAVA_HOME/bin
 
 # passwordless ssh

--- a/apache-spark-master/Dockerfile
+++ b/apache-spark-master/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
   apt-get install -y \
     python \
     libnss3 \
-    openjdk-7-jre-headless \
+    openjdk-8-jre-headless \
     curl
 
 # pull down spark jar

--- a/apache-spark-worker/Dockerfile
+++ b/apache-spark-worker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu
 MAINTAINER Frank Austin Nothaft, fnothaft@berkeley.edu
 
 RUN apt-get update && \
-  apt-get install -y python libnss3 openjdk-7-jre-headless curl
+  apt-get install -y python libnss3 openjdk-8-jre-headless curl
 
 # pull down spark jar
 RUN mkdir /opt/apache-spark && \

--- a/spark-and-maven/build/Dockerfile
+++ b/spark-and-maven/build/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Frank Austin Nothaft, fnothaft@berkeley.edu
 
 RUN apt-get update && apt-get install -y \
 	git \
-	openjdk-7-jdk \
+	openjdk-8-jdk \
 	python \
 	libnss3 \
 	curl


### PR DESCRIPTION
- Points to main ADAM repository at https://github.com/bigdatagenomics/adam.
- Bumps to ADAM 0.20.0 release candidate at commit hash c251f79c6bde3dce12e685c6cf03d5b1c30e9273.
- Upgrade to JDK8.
