### PR TITLE
Revised mono-docker ADAM pipeline to not depend on Docker socket (resolves #147)

### DIFF
--- a/adam-pipeline/Dockerfile
+++ b/adam-pipeline/Dockerfile
@@ -1,21 +1,16 @@
-FROM ubuntu:14.04
+FROM quay.io/ucsc_cgl/adam:962-ehf--be13567d00cd4c586edf8ae47d991815c8c72a49
 
 MAINTAINER Frank Austin Nothaft, fnothaft@berkeley.edu
 
 RUN apt-get update && apt-get install -y \
-	git \
-	openjdk-7-jdk \
 	python-dev \
 	python-pip \
 	libnss3 \
+	git \
 	curl \
 	wget \
 	apt-transport-https \
 	ca-certificates
-
-# Get the 1.9.1 binary
-RUN wget https://get.docker.com/builds/Linux/x86_64/docker-1.9.0 -O /usr/local/bin/docker
-RUN chmod u+x /usr/local/bin/docker
 
 # Install Toil
 RUN pip install toil==3.3.0

--- a/adam-pipeline/Makefile
+++ b/adam-pipeline/Makefile
@@ -3,7 +3,7 @@ runtime_fullpath = $(realpath runtime)
 build_tool = runtime-container.DONE
 git_commit ?= $(shell git log --pretty=oneline -n 1 -- ../rnaseq-cgl-pipeline | cut -f1 -d " ")
 name = quay.io/ucsc_cgl/adam-pipeline
-tag = 732349f6dd0df3fb90fa9d7e6ee1e04a32e2e773--${git_commit}
+tag = f7512d5ac3bcaa40fa2682236c2f1b44020a2861--${git_commit}
 
 build:
 	docker build -t ${name}:${tag} .

--- a/adam-pipeline/README.md
+++ b/adam-pipeline/README.md
@@ -24,29 +24,18 @@ Additionally, we expect a path to a known sites file. This is a file that
 describes positions where variants are known to occur, and is used to mask
 out sites during base quality score recalibration. Typically, a dbSNP VCF file
 is used. This pipeline requires a run environment with at least 10G of memory
-to run BQSR with a known sites file from dbSNP.
-
-This pipeline requires a host with Docker 1.9.0 installed. Other versions of
-Docker will soon be supported.
+to run BQSR with a known sites file from dbSNP. You should provide a path where
+the output data should be written.
 
 ## Running
-
-Mirror the absolute path to the parent directory when using Docker's -v mount
-command. Toil's job store and temporary directories will be created inside this
-mount point. "-v /var/run/docker.sock:/var/run/docker.sock" must always be
-supplied. This is necessary for the ADAM pipeline Docker container to run
-the Docker containers it relies on.
-
-To reiterate, the mount for the working directory must match on both sides of the colon.
-An error will be thrown if that is not the case. 
 
 ```
 docker run \
     -v /foo/bar:/foo/bar \
-    -v /var/run/docker.sock:/var/run/docker.sock \
     quay.io/ucsc_cgl/adam-pipeline \
     --sample /foo/bar/<input_sample>.{sam,bam} \
-    --known-sites /foo/bar/<known_sites>.vcf
+    --known-sites /foo/bar/<known_sites>.vcf \
+    --output /foo/bar/<path_to_write_output> \
     --memory <memory_setting>
 ```
 

--- a/adam-pipeline/test.py
+++ b/adam-pipeline/test.py
@@ -11,7 +11,7 @@ class TestADAMPipeline(unittest.TestCase):
         
         # get working directory
         pwd = os.getcwd()
-        outfile = '%s/test/small.processed.bam' % pwd
+        outfile = '%s/test/outdir/small.processed.bam' % pwd
 
         # check for output file in ./test and clean if necessary
         if os.path.exists(outfile):
@@ -22,16 +22,18 @@ class TestADAMPipeline(unittest.TestCase):
         base = ['docker', 'run']
         args = ['--sample', '/%s/test/small.sam' % pwd,
                 '--known-sites', '/%s/test/small.vcf' % pwd,
+                '--output', '/%s/test/outdir/small.processed.bam' % pwd,
                 '--memory', '1']
-        sock = ['-v', '/var/run/docker.sock:/var/run/docker.sock']
-        mirror = ['-v', '/%s/test:/%s/test' % (pwd, pwd)]
+        mounts = ['-v', '/%s/test/small.sam:/%s/test/small.sam' % (pwd, pwd),
+                  '-v', '/%s/test/small.vcf:/%s/test/small.vcf' % (pwd, pwd),
+                  '-v', '/%s/test/outdir:/%s/test/outdir' % (pwd, pwd),]
 
         # Check base call for help menu
         out = subprocess.check_output(base + tool)
         self.assertTrue('Please see the complete documentation' in out)
 
         # run full command on sample inputs and check for existence of output file
-        subprocess.check_call(base + sock + mirror + tool + args)
+        subprocess.check_call(base + mounts + tool + args)
         self.assertTrue(os.path.exists(outfile))
 
 


### PR DESCRIPTION
Depends on https://github.com/BD2KGenomics/toil-scripts/pull/351, which adds support for running a "native" ADAM installation. Here, we've modified the adam-pipeline container to extend from the adam container, which provides a native install of ADAM.
