### PR TITLE
Modified adam-pipeline to pass default memory (resolves #151)

### DIFF
--- a/adam-pipeline/wrapper.py
+++ b/adam-pipeline/wrapper.py
@@ -62,6 +62,7 @@ def call_pipeline(args):
                '--config', conf,
                '--sample', args.sample,
                '--defaultDisk', '0',
+               '--defaultMemory', '%sG' % args.memory,
                '--maxDisk', '0']
     
     # run the command and clean up
@@ -69,7 +70,7 @@ def call_pipeline(args):
         subprocess.check_call(command)
     finally:
         stat = os.stat(args.output)
-        subprocess.check_call(['chown', '-R', '{}:{}'.format(stat.st_uid, stat.st_gid), args.output])
+        subprocess.check_call(['chown', '-R', '{}:{}'.format(stat.st_uid, stat.st_gid), os.path.dirname(args.output)])
         shutil.rmtree(work_dir)
 
 


### PR DESCRIPTION
I've modified the wrapper script for the adam-pipeline image to pass the memory requested by the user as the default memory to request for a job. This resolves an issue where a user running on a machine with a low amount of memory gets OOM asserts from Toil, even though the Spark job doesn't request much memory.
