### PR TITLE
Adding a WDL demo

### DIFF
--- a/adam-pipeline/.gitignore
+++ b/adam-pipeline/.gitignore
@@ -1,0 +1,1 @@
+workflow.json

--- a/adam-pipeline/Dockerfile
+++ b/adam-pipeline/Dockerfile
@@ -25,5 +25,5 @@ RUN cd /opt/adam-pipeline && make develop
 COPY wrapper.py /opt/adam-pipeline/
 COPY README.md /opt/adam-pipeline/
 
-ENTRYPOINT ["python", "/opt/adam-pipeline/wrapper.py"]
-CMD ["--help"]
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD [ "python /opt/adam-pipeline/wrapper.py --help"]

--- a/adam-pipeline/Makefile
+++ b/adam-pipeline/Makefile
@@ -15,8 +15,11 @@ push: build
 	docker push ${name}:${tag}
 	docker push ${name}:latest
 
-test: build
-	python test.py
+test: build workflow.json
+	python test.py -b
+
+workflow.json: workflow.json.template
+	sed -e "s:PWD:${PWD}:g" workflow.json.template > workflow.json
 
 clean:
-	-rm ${build_tool}
+	-rm ${build_tool} workflow.json

--- a/adam-pipeline/README.md
+++ b/adam-pipeline/README.md
@@ -29,7 +29,7 @@ the output data should be written.
 
 ## Testing
 
-There is an automated test included simply install Docker, make, and Python 2.7 for your 
+There is an automated test included simply install Docker, make, and Python 2.7 for your
 platform and do the following:
 
     make test
@@ -51,3 +51,16 @@ docker run \
 The memory setting for this pipeline is used to set the amount of memory used
 by ADAM, and should be the amount of memory in gigabytes that you would like
 to allocate.
+
+## Running in Cromwell
+
+Before you attempt this make sure you have Cromwell installed and have built the
+container above using `make test` (or the container has been pushed to quay.io).
+
+Then make sure you update workflow.json so the paths are correct for your system.
+
+You can run this tool with a very simple WDL workflow using the following:
+
+    cromwell run workflow.wdl workflow.json
+
+Look for the output bam where you specified in the `workflow.json`.

--- a/adam-pipeline/test.py
+++ b/adam-pipeline/test.py
@@ -8,7 +8,7 @@ import unittest
 class TestADAMPipeline(unittest.TestCase):
 
     def test_docker_call(self):
-        
+
         # get working directory
         pwd = os.getcwd()
         outfile = '%s/test/outdir/small.processed.bam' % pwd
@@ -20,7 +20,8 @@ class TestADAMPipeline(unittest.TestCase):
         # build commandline
         tool = ['quay.io/ucsc_cgl/adam-pipeline']
         base = ['docker', 'run']
-        args = ['--sample', '/%s/test/small.sam' % pwd,
+        args = ['python', '/opt/adam-pipeline/wrapper.py',
+                '--sample', '/%s/test/small.sam' % pwd,
                 '--known-sites', '/%s/test/small.vcf' % pwd,
                 '--output', '/%s/test/outdir/small.processed.bam' % pwd,
                 '--memory', '1']
@@ -29,11 +30,13 @@ class TestADAMPipeline(unittest.TestCase):
                   '-v', '/%s/test/outdir:/%s/test/outdir' % (pwd, pwd),]
 
         # Check base call for help menu
+        print (base + tool)
         out = subprocess.check_output(base + tool)
         self.assertTrue('Please see the complete documentation' in out)
 
         # run full command on sample inputs and check for existence of output file
-        subprocess.check_call(base + mounts + tool + args)
+        print (base + mounts + tool + [" ".join(args)])
+        subprocess.check_call(base + mounts + tool + [" ".join(args)])
         self.assertTrue(os.path.exists(outfile))
 
 

--- a/adam-pipeline/test/outdir/placeholder
+++ b/adam-pipeline/test/outdir/placeholder
@@ -1,1 +1,0 @@
-a placeholder so the output directory exists

--- a/adam-pipeline/workflow.json
+++ b/adam-pipeline/workflow.json
@@ -1,6 +1,0 @@
-{
-  "wf.adam.in": "/Users/boconnor/Development/gitroot/BD2KGenomics/cgl-docker-lib/adam-pipeline/test/small.sam",
-  "wf.adam.knownSites": "/Users/boconnor/Development/gitroot/BD2KGenomics/cgl-docker-lib/adam-pipeline/test/small.vcf",
-  "wf.adam.mem": "1",
-  "wf.adam.out": "/Users/boconnor/Development/gitroot/BD2KGenomics/cgl-docker-lib/adam-pipeline/test/outdir/small.processed.bam"
-}

--- a/adam-pipeline/workflow.json
+++ b/adam-pipeline/workflow.json
@@ -1,0 +1,6 @@
+{
+  "wf.adam.in": "/Users/boconnor/Development/gitroot/BD2KGenomics/cgl-docker-lib/adam-pipeline/test/small.sam",
+  "wf.adam.knownSites": "/Users/boconnor/Development/gitroot/BD2KGenomics/cgl-docker-lib/adam-pipeline/test/small.vcf",
+  "wf.adam.mem": "1",
+  "wf.adam.out": "/Users/boconnor/Development/gitroot/BD2KGenomics/cgl-docker-lib/adam-pipeline/test/outdir/small.processed.bam"
+}

--- a/adam-pipeline/workflow.json.template
+++ b/adam-pipeline/workflow.json.template
@@ -1,0 +1,6 @@
+{
+  "wf.adam.in": "PWD/test/small.sam",
+  "wf.adam.knownSites": "PWD/test/small.vcf",
+  "wf.adam.mem": "1",
+  "wf.adam.out": "PWD/test/outdir/small.processed.bam"
+}

--- a/adam-pipeline/workflow.wdl
+++ b/adam-pipeline/workflow.wdl
@@ -1,0 +1,22 @@
+task adam {
+  File in
+  File knownSites
+  String mem
+
+  command {
+    python /opt/adam-pipeline/wrapper.py --known-sites ${knownSites} --sample ${in} --output `pwd`/small.processed.bam --memory ${mem}
+  }
+
+  runtime {
+    docker: "quay.io/ucsc_cgl/adam-pipeline"
+  }
+
+  output {
+    File response = "small.processed.bam"
+  }
+
+}
+
+workflow wf {
+  call adam
+}

--- a/adam-pipeline/wrapper.py
+++ b/adam-pipeline/wrapper.py
@@ -70,7 +70,7 @@ def call_pipeline(args):
         subprocess.check_call(command)
     finally:
         stat = os.stat(args.output)
-        subprocess.check_call(['chown', '-R', '{}:{}'.format(stat.st_uid, stat.st_gid), os.path.dirname(args.output)])
+        subprocess.check_call(['chown', '-R', '{}:{}'.format(stat.st_uid, stat.st_gid), args.output])
         shutil.rmtree(work_dir)
 
 


### PR DESCRIPTION
I added a WDL workflow and instructions on how to call this tool via WDL.  I wanted to test that this tool is callable via Cromwell locally since I thought it would help with testing on the Broad's side.

I found that the ENTRYPOINT in Frank's Docker wasn't compatible with the way Cromwell calls the tool.  It seems to assume the entrypoint is bash and pipes in the command.  

To make this concrete, here's how Cromwell executes a command in a given Docker container:

```
"/bin/bash" "-c" "cat cromwell-executions/wf/ac99b2c7-2204-4827-a974-3873c3e6b5c5/call-adam/script | docker run --rm -v /Users/boconnor/Development/gitroot/BD2KGenomics/cgl-docker-lib/adam-pipeline/cromwell-executions/wf/ac99b2c7-2204-4827-a974-3873c3e6b5c5/call-adam:/root/wf/ac99b2c7-2204-4827-a974-3873c3e6b5c5/call-adam -i quay.io/ucsc_cgl/adam-pipeline /bin/bash <&0"
```

Feel free to tweak as needed or discard if I'm not understanding the issue properly.

I don't think I'm handling the output file correctly since it's not copied back to the output path specified in the JSON.  I leave that for the Broad folks to comment on/fix.
