### PR TITLE
Tag bwakit:latest after building (resolves #171)

### DIFF
--- a/bwakit/Makefile
+++ b/bwakit/Makefile
@@ -7,6 +7,7 @@ build: ${build_tool}
 
 ${build_tool}: Dockerfile
 	docker build -t ${name}:${tag} .
+	docker tag -f ${name}:${tag} ${name}:latest
 	touch ${build_tool}
 
 push: build


### PR DESCRIPTION
In the bwakit build, we were pushing the bwakit:latest container, but we'd never tagged a :latest revision. I've modified the `make build` target for bwakit to tag a latest after building.
