### PR TITLE
Update quinine docker image to pull in cloud pilot fixes (resolves #193)

### DIFF
--- a/quinine/Makefile
+++ b/quinine/Makefile
@@ -7,7 +7,7 @@ build_tool = runtime-container.DONE
 build_number ?= none
 git_commit ?= $(shell git rev-parse HEAD)
 name = quay.io/ucsc_cgl/quinine
-tag = 2475aea0f800ce293dbf18e743c500a0cd51e403--${git_commit}
+tag = a987006fdf38afadc9c6a22061885f8e105234f7--${git_commit}
 
 # Steps
 build: ${build_output} ${build_tool}

--- a/quinine/build/Dockerfile
+++ b/quinine/build/Dockerfile
@@ -9,6 +9,6 @@ RUN git clone https://github.com/bigdatagenomics/quinine.git
 
 # build quinine
 WORKDIR /home/quinine
-RUN git checkout 2475aea0f800ce293dbf18e743c500a0cd51e403
+RUN git checkout a987006fdf38afadc9c6a22061885f8e105234f7
 
 RUN /opt/apache-maven-3.3.9/bin/mvn package -DskipTests


### PR DESCRIPTION
Pulls in:
- https://github.com/bigdatagenomics/quinine/pull/43
- https://github.com/bigdatagenomics/quinine/pull/45

Ping @hannes-ucsc @jvivian can I get a quick review/merge on this? I need to get this to Chet, preferably by EOD today.
