### PR TITLE
Build cleanup to try and (resolves #199)

### DIFF
--- a/apache-spark-master/Makefile
+++ b/apache-spark-master/Makefile
@@ -1,5 +1,5 @@
 build_tool = runtime-container.DONE
-git_commit ?= $(shell git log --pretty=oneline -n 1 -- ../apache-spark-master | cut -f1 -d " ")
+git_commit ?= $(shell git log --pretty=oneline -n 1 -- ../apache-spark-common ../apache-spark-master | cut -f1 -d " ")
 nametag = quay.io/ucsc_cgl/apache-spark-master:1.5.2--${git_commit}
 
 build: ${build_tool}

--- a/apache-spark-worker/Makefile
+++ b/apache-spark-worker/Makefile
@@ -1,5 +1,5 @@
 build_tool = runtime-container.DONE
-git_commit ?= $(shell git log --pretty=oneline -n 1 -- ../apache-spark-worker | cut -f1 -d " ")
+git_commit ?= $(shell git log --pretty=oneline -n 1 -- ../apache-spark-common ../apache-spark-worker | cut -f1 -d " ")
 nametag = quay.io/ucsc_cgl/apache-spark-worker:1.5.2--${git_commit}
 
 build: ${build_tool}

--- a/jenkins.py
+++ b/jenkins.py
@@ -46,6 +46,7 @@ def get_updated_tools(repos):
             output = subprocess.check_output(dryrun_cmd,
                                              cwd=os.path.abspath(tool),
                                              stderr=subprocess.STDOUT)
+
         except subprocess.CalledProcessError as cpe:
             _log.error('Calling %r on tool %s failed with error code %d! Output:', 
                        dryrun_cmd, tool, cpe.returncode)
@@ -53,6 +54,19 @@ def get_updated_tools(repos):
 
             for line in output_lines:
                 _log.debug('%s/%r: %s', tool, dryrun_cmd, line)
+
+            _log.error('Skipping...')
+
+            # set a null output and we'll fall through this loop iteration
+            output = None
+
+        except Exception as e:
+
+            # we may catch other exceptions too, such as an OSError if chdir doesn't work
+            # let's just generically catch and log these here
+            _log.error('Caught exception when trying to call %r on tool %s:\n%r',
+                       dryrun_cmd, tool, e)
+            _log.error('Skipping...')
 
             # set a null output and we'll fall through this loop iteration
             output = None

--- a/jenkins.py
+++ b/jenkins.py
@@ -13,11 +13,16 @@ Requires
     ~/.dockercfg (with privileges to quay.io/ucsc_cgl/)
     ~/.cgl-docker-lib (containing the quay.io access token need to authenticate POST requests)
 """
+
+import json
+import logging
 import os
 import subprocess
 import requests
-import json
 
+# get a log with the most basic config
+_log = logging.getLogger(__name__)
+logging.basicConfig()
 
 def get_updated_tools(repos):
     """
@@ -28,15 +33,19 @@ def get_updated_tools(repos):
         # Load API request for image
         response = requests.get('https://quay.io/api/v1/repository/ucsc_cgl/{}/image/'.format(tool))
         json_data = json.loads(response.text)
-        assert response.status_code == 200, 'Quay.io API Request to view repository: {}, has failed'.format(tool)
+        if response.status_code != 200:
+            _log.error('Quay.io API Request to view repository: %s, has failed', tool)
+
         # Fetch quay.io tags and parse for commit hash
         tags = sum([x['tags'] for x in json_data['images'] if x['tags']], [])
-        tags = {str(x).split('--')[1] for x in tags if '--' in x}
+        _log.debug('Tool %s has %d tags on quay.io:\n%r', tool, len(tags), tags)
 
         # identify tools that will be built from make push dry run
         output = subprocess.check_output(['make', '-n', 'push'], cwd=os.path.abspath(tool))
         if output:
             lines = output.split('\n')
+            pushed_tags = []
+            added = False
             
             for line in lines:
                 # make push may:
@@ -48,17 +57,32 @@ def get_updated_tools(repos):
 
                     # we expect the push command to be "docker push toolname:tag", thus we're interested in the 3rd word
                     push_cmd = line.split()
-                    assert(len(push_cmd) == 3, 'Saw badly formatted push command for %s (%r)' % (tool, push_cmd))
+                    if len(push_cmd) != 3:
+                        _log.error('Saw badly formatted push command for %s (%r)', tool, push_cmd)
 
                     # split the toolname/tag on the semicolon to get the tag
                     push_tool_and_tag = push_cmd[2]
                     push_tool, version = push_tool_and_tag.split(':', 1)
-                    assert(push_tool == tool, 'Tool name in push command (%s) did not match expected (%s).'.format(push_tool, tool))
+                    if push_tool != tool:
+                        _log.error('Tool name in push command (%s) did not match expected (%s).', push_tool, tool)
+                    pushed_tags.append(version)
                     
                     if version not in tags:
                         updated_tools.add(tool)
+                        added = True
+
+            if len(pushed_tags) > 1:
+                _log.warn('Saw multiple tags for %s: %r', tool, pushed_tags)
+            elif len(pushed_tags) == 0:
+                _log.warn('Saw no tags to push for %s.', tool)
+
+            if added:
+                _log.info('Added %s to list of updated tools.', tool)
+            else:
+                _log.info('Did not add %s to list of updated tools.', tool)
+
         else:
-            print 'Skipping tool, as it does not exist in cgl-docker-lib: ' + tool
+            _log.warn('Skipping tool %s, as it does not exist in cgl-docker-lib.', tool)
 
     return updated_tools
 
@@ -69,7 +93,8 @@ def get_repos():
     """
     response = requests.get('https://quay.io/api/v1/repository?public=true&namespace=ucsc_cgl')
     repo_data = json.loads(response.text)
-    assert response.status_code == 200, 'Quay.io API request to view repositories failed.'
+    if response.status_code != 200:
+        raise RuntimeError('Quay.io API request to view repositories failed with code %d.' % response.statusCode)
     repos = {str(x[u'name']) for x in repo_data['repositories']}
     return repos
 
@@ -80,10 +105,18 @@ def run_make(tools_to_build, cmd, err):
     For each tool, run a (make) command with an error message if it fails
     """
     for tool in tools_to_build:
-        print '\nTool: {}\n'.format(tool)
+        _log.info('Running "%s" for tool %s.', cmd, tool)
         try:
-            subprocess.check_call(cmd, cwd=os.path.abspath(tool))
-        except subprocess.CalledProcessError:
+            subprocess.check_output(cmd, cwd=os.path.abspath(tool))
+            _log.info('Running "%s" for tool %s succeeded!', cmd, tool)
+        except subprocess.CalledProcessError as cpe:
+            _log.error('Running "%s" for tool %s FAILED with code %d! Output:',
+                       cmd, tool, cpe.returncode)
+            output_lines = cpe.output.split('\n')
+
+            for line in output_lines:
+                _log.debug('%s/%s: %s', tool, cmd, line)
+
             if cmd == 'make':
                 raise RuntimeError, err.format(tool)
             # If a test fails, an assertion will be thrown. Sometimes "make test" returns non-zero exit codes.
@@ -98,22 +131,30 @@ def make_repos_public(tools_to_build, credentials):
     with open(credentials, 'r') as f:
         token = f.read().strip()
     for tool in tools_to_build:
-        print 'Making tool: {} a publically visible repository.'.format(tool)
+        _log.info('Making tool: %s a publically visible repository.', tool)
         url = 'https://quay.io/api/v1/repository/ucsc_cgl/{}/changevisibility'.format(tool)
         payload = {'visibility': 'public'}
         headers = {'Authorization': 'Bearer {}'.format(token), 'content-type': 'application/json'}
         response = requests.post(url, data=json.dumps(payload), headers=headers)
-        assert response.status_code == 200, 'POST call failed. Code: {}. 403 = bad token'.format(response.status_code)
 
+        if response.status_code != 200:
+            _log.error('POST call to make %s public failed. Code: %d. 403 = bad token',
+                       tool,
+                       response.status_code)
+        else:
+            _log.info('Succeeded in making %s public!', tool)
 
 def main():
     push = building_on_master()
+    if push:
+        _log.info('We are building the master branch, so we will push updated containers.')
     # Determine what tools to build
     tools = {x for x in os.listdir('.') if os.path.isdir(x) and not x.startswith('.')}
     repos = get_repos()
     updated_tools = get_updated_tools(repos)
     tools_to_build = (tools - repos).union(updated_tools)
-    print 'Building Tools: ' + ' '.join(tools_to_build)
+    _log.info('Building %d tools out of %d: %s',
+              len(tools), len(repos), '\n'.join(tools_to_build))
     # Build, test, and push tools to quay.io/ucsc_cgl/
     cmds = [["make"], ["make", "test"]]
     errs = ['Tool: {}, failed to build', 'Tool: {}, failed unittest']
@@ -131,7 +172,8 @@ def main():
 def building_on_master():
     master_sha1 = subprocess.check_output(['git', 'rev-parse', '--verify', 'remotes/origin/master']).strip()
     head_sha1 = subprocess.check_output(['git', 'rev-parse', '--verify', 'HEAD']).strip()
-    return head_sha1 == master_sha1
+    _log.info('Got sha1 of %s for remote/origin/master, sha1 of %s for local HEAD.', master_sha1, head_sha1)
+    return (head_sha1 == master_sha1)
 
 
 if __name__ == '__main__':

--- a/jenkins.py
+++ b/jenkins.py
@@ -183,7 +183,7 @@ def main():
     updated_tools = get_updated_tools(repos)
     tools_to_build = (tools - repos).union(updated_tools)
     _log.info('Building %d tools out of %d: %s',
-              len(tools - repos), len(repos), '\n'.join(tools_to_build))
+              len(tools_to_build), len(repos), '\n'.join(tools_to_build))
     # Build, test, and push tools to quay.io/ucsc_cgl/
     cmds = [["make"], ["make", "test"]]
     errs = ['Tool: {}, failed to build', 'Tool: {}, failed unittest']

--- a/jenkins.py
+++ b/jenkins.py
@@ -34,6 +34,11 @@ def get_updated_tools(repos):
     updated_tools = set()
     dryrun_cmd = ['make', '-n', 'push']
     for tool in repos:
+        
+        if not os.path.isdir(os.path.abspath(tool)):
+            _log.warn('Tool %s does not exist in cgl-docker-lib. Skipping...', tool)
+            continue
+
         # Load API request for image
         response = requests.get('https://quay.io/api/v1/repository/ucsc_cgl/{}/image/'.format(tool))
         json_data = json.loads(response.text)
@@ -58,17 +63,6 @@ def get_updated_tools(repos):
             for line in output_lines:
                 _log.debug('%s/%r: %s', tool, dryrun_cmd, line)
 
-            _log.error('Skipping...')
-
-            # set a null output and we'll fall through this loop iteration
-            output = None
-
-        except Exception as e:
-
-            # we may catch other exceptions too, such as an OSError if chdir doesn't work
-            # let's just generically catch and log these here
-            _log.error('Caught exception when trying to call %r on tool %s:\n%r',
-                       dryrun_cmd, tool, e)
             _log.error('Skipping...')
 
             # set a null output and we'll fall through this loop iteration

--- a/jenkins.py
+++ b/jenkins.py
@@ -124,6 +124,7 @@ def get_updated_tools(repos):
                     push_cmd = line.split()
                     if len(push_cmd) != 3:
                         _log.error('Saw badly formatted push command for %s (%r)', tool, push_cmd)
+                        continue
 
                     # split the toolname/tag on the semicolon to get the tag
                     push_tool_and_tag = push_cmd[2]

--- a/jenkins.py
+++ b/jenkins.py
@@ -25,7 +25,7 @@ _log = logging.getLogger(__name__)
 logging.basicConfig()
 
 # log all the things
-_log.setLevel(5)
+_log.setLevel(9)
 
 def get_updated_tools(repos):
     """
@@ -42,7 +42,7 @@ def get_updated_tools(repos):
 
         # Fetch quay.io tags and parse for commit hash
         tags = sum([x['tags'] for x in json_data['images'] if x['tags']], [])
-        _log.debug('Tool %s has %d tags on quay.io:\n%r', tool, len(tags), tags)
+        _log.log(5, 'Tool %s has %d tags on quay.io:\n%r', tool, len(tags), tags) # lower level than debug
 
         # identify tools that will be built from make push dry run
         try:

--- a/jenkins.py
+++ b/jenkins.py
@@ -24,6 +24,9 @@ import requests
 _log = logging.getLogger(__name__)
 logging.basicConfig()
 
+# log all the things
+_log.setLevel(5)
+
 def get_updated_tools(repos):
     """
     Compare latest git commit hash of a tool to the existing tag on quay.io.

--- a/jenkins.py
+++ b/jenkins.py
@@ -43,7 +43,9 @@ def get_updated_tools(repos):
 
         # identify tools that will be built from make push dry run
         try:
-            output = subprocess.check_output(dryrun_cmd, cwd=os.path.abspath(tool))
+            output = subprocess.check_output(dryrun_cmd,
+                                             cwd=os.path.abspath(tool),
+                                             stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as cpe:
             _log.error('Calling %r on tool %s failed with error code %d! Output:', 
                        dryrun_cmd, tool, cpe.returncode)
@@ -121,7 +123,9 @@ def run_make(tools_to_build, cmd, err):
     for tool in tools_to_build:
         _log.info('Running "%s" for tool %s.', cmd, tool)
         try:
-            subprocess.check_output(cmd, cwd=os.path.abspath(tool))
+            subprocess.check_output(cmd,
+                                    cwd=os.path.abspath(tool),
+                                    stderr=subprocess.STDOUT)
             _log.info('Running "%s" for tool %s succeeded!', cmd, tool)
         except subprocess.CalledProcessError as cpe:
             _log.error('Running "%s" for tool %s FAILED with code %d! Output:',

--- a/jenkins.py
+++ b/jenkins.py
@@ -183,7 +183,7 @@ def main():
     updated_tools = get_updated_tools(repos)
     tools_to_build = (tools - repos).union(updated_tools)
     _log.info('Building %d tools out of %d: %s',
-              len(tools), len(repos), '\n'.join(tools_to_build))
+              len(tools - repos), len(repos), '\n'.join(tools_to_build))
     # Build, test, and push tools to quay.io/ucsc_cgl/
     cmds = [["make"], ["make", "test"]]
     errs = ['Tool: {}, failed to build', 'Tool: {}, failed unittest']


### PR DESCRIPTION
Apologies in advance for the hacky title. This cleans up these two bits from #199:
- [x] jenkins.py assumes that all tools are tagged with a specific git revision
- [x] jenkins.py logging is a mess (hard to track where log messages are coming from, important things aren't logged)

I haven't tested this locally, since it relies on quay.io credentials (that I don't have). So, let's let Jenkins DO IT LIVE.
