### PR TITLE
Fix kallisto tagging in makefile (resolves #238)

### DIFF
--- a/kallisto/Makefile
+++ b/kallisto/Makefile
@@ -9,6 +9,7 @@ tag = 0.43.1--${git_commit}
 # Steps
 build:
 	docker build -t ${name}:${tag} .
+	-docker rmi -f ${name}:latest
 	docker tag ${name}:${tag} ${name}:latest
 	touch ${build_tool}
 


### PR DESCRIPTION
Docker's backwards compatibility is frustrating — they removed the `-f` flag from `docker tag` at some point. 